### PR TITLE
Adds method to hook a callback on stderr output

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ function Ogr2ogr(mixed, fmt) {
   else {
     this._inPath = mixed
   }
-
+  
+  this._onStderr=function() {};
   this._driver = {}
   this._args = []
   this._timeout = 15000
@@ -74,6 +75,11 @@ Ogr2ogr.prototype.timeout = function(ms) {
 Ogr2ogr.prototype.project = function(dest, src) {
   this._targetSrs = dest
   if (src) this._sourceSrs = src
+  return this
+}
+
+Ogr2ogr.prototype.onStderr = function(fn) {
+  this._onStderr=fn;
   return this
 }
 
@@ -176,6 +182,7 @@ Ogr2ogr.prototype._run = function() {
 
     s.stderr.setEncoding('ascii')
     s.stderr.on('data', function(chunk) {
+      ogr2ogr._onStderr(chunk);
       errbuf += chunk
     })
     s.on('error', function(err) {


### PR DESCRIPTION
I was experimenting a weird behavior when exporting a GeoJSON file to a PG database.

I found out you can set the option [CPL_DEBUG](https://trac.osgeo.org/gdal/wiki/ConfigOptions#CPL_DEBUG) to `ON`, which does print ogr2ogr inner messages and warnings to the console when running it from CLI. However, said option had no effect when using this library.

In this PR I'm setting a callback function as an instance method, which is a `noop` by default

```js
this._onStderr=function() {};
```

But you can configure it using:

```js
Ogr2ogr.prototype.onStderr = function(fn) {
  this._onStderr=fn;
  return this
}
```

Then, inside the `run` method, this function is called as:


```js
    s.stderr.on('data', function(chunk) {
      ogr2ogr._onStderr(chunk);
      errbuf += chunk
    })
```

So, by default, it does nothing, but if you (as it happened in my case) did:

```js
var ogrStream = ogr2ogr(inputFile)
	.format('PostgreSQL')
	.options(["--config", "CPL_DEBUG", "ON"])
	.timeout(options.timeout)
	.project('EPSG:4326')
	.destination(options.connString)
	.onStderr(function (data) {  // this is where I hook the callback!
		debug(data);
	})
	.stream();
```js
The output of ogr2ogr will be printed to the console e.g

```sh
PG: PostgreSQL version string : 'PostgreSQL 9.6.6 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.3 20140911 (Red Hat 4.8.3-9), 64-bit'
PG: PostGIS version string : '2.3 USE_GEOS=1 USE_PROJ=1 USE_STATS=1'
PG: Primary key name (FID): ogc_fid, type : int4
Warning 6: dataset PG:host=xx.rds.amazonaws.com port=5432 user=xxx dbname=ddbb password=asdfg does not support layer creation option SRID
```

Which in my case was very helpful.